### PR TITLE
Fix for sklearn version >= 0.24.1

### DIFF
--- a/dynGENIE3_python/dynGENIE3.py
+++ b/dynGENIE3_python/dynGENIE3.py
@@ -1,4 +1,4 @@
-from sklearn.tree.tree import BaseDecisionTree
+from sklearn.tree import BaseDecisionTree
 from sklearn.ensemble import RandomForestRegressor, ExtraTreesRegressor
 from numpy import *
 from numpy.random import permutation, uniform
@@ -19,7 +19,7 @@ def compute_feature_importances(estimator):
     else:
         importances = [e.tree_.compute_feature_importances(normalize=False)
                        for e in estimator.estimators_]
-        importances = asarray(importances)
+        importances = array(importances)
         return sum(importances,axis=0) / len(estimator)
 
 


### PR DESCRIPTION
`sklearn.tree.tree` module does not exist on the later versions of `scikit-learn` and therefore causes an error. 